### PR TITLE
feat: allow saved schedules colors' to be changed

### DIFF
--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -27,30 +27,21 @@ export default function Announcement() {
 
   const hasHydrated = useGlobalStore.persist.hasHydrated();
 
-  const title = "Quality of Life Update!";
-  const description = "We have added some new features to our website!";
-  const patchDate = "2024-12-14";
+  const title = "Slight Update!";
+  const description =
+    "We have added some a couple of new features to the website!";
+  const patchDate = "2024-12-16";
 
   const updates = [
     {
-      title: "Customizable Colors",
+      title: "New Filters",
       description:
-        "Course Colors are now customizable in Schedules! You can also now set if you want to randomize colors.",
+        "New filters have been added to the classes table! You can now filter by professor, section, and even remarks!",
     },
     {
-      title: "Selected Rows Indicator",
+      title: "Change Saved Schedule Colors",
       description:
-        "You can now see how many rows have been selected for a specific course on the course list.",
-    },
-    {
-      title: "Clear Selected Rows",
-      description:
-        "All rows can now be cleared on the click of one button! You can see it near the Course List.",
-    },
-    {
-      title: "Toggle Columns",
-      description:
-        "Table Columns can now be hidden/shown using the 'View' button at the top-right corner of the table.",
+        "You can now change the colors of your saved schedules! Click on the Palette Button near the Download button to change it.",
     },
   ];
 

--- a/src/components/CourseColorsDialog.tsx
+++ b/src/components/CourseColorsDialog.tsx
@@ -1,3 +1,4 @@
+import { SavedSchedule } from "@/lib/definitions";
 import { ColorsEnumSchema } from "@/lib/enums";
 import { getCardColors } from "@/lib/utils";
 import { useGlobalStore } from "@/stores/useGlobalStore";
@@ -20,23 +21,41 @@ import { ScrollArea } from "./ui/scroll-area";
 import { Switch } from "./ui/switch";
 import { toast } from "./ui/use-toast";
 
-interface CourseColorsDialogProps {}
-export default function CourseColorsDialog({}: CourseColorsDialogProps) {
-  const { courseColors, setCourseColors, randomizeColors, setRandomizeColors } =
-    useGlobalStore(
-      useShallow((state) => ({
-        courseColors: state.courseColors,
-        setCourseColors: state.setCourseColors,
-        randomizeColors: state.randomizeColors,
-        setRandomizeColors: state.setRandomizeColors,
-      }))
-    );
+interface CourseColorsDialogProps {
+  savedSchedule?: SavedSchedule;
+}
 
-  const [colors, setColors] = useState(() => ({ ...courseColors }));
+export default function CourseColorsDialog({
+  savedSchedule,
+}: CourseColorsDialogProps) {
+  const {
+    courseColors,
+    setCourseColors,
+    randomizeColors,
+    setRandomizeColors,
+    changeSavedColors,
+  } = useGlobalStore(
+    useShallow((state) => ({
+      courseColors: state.courseColors,
+      setCourseColors: state.setCourseColors,
+      randomizeColors: state.randomizeColors,
+      setRandomizeColors: state.setRandomizeColors,
+      changeSavedColors: state.changeSavedColors,
+    }))
+  );
+
+  const [colors, setColors] = useState(() => ({
+    ...(savedSchedule ? savedSchedule.colors : courseColors),
+  }));
   const [open, setOpen] = useState(false);
 
   const handleSave = () => {
-    setCourseColors(colors);
+    if (!savedSchedule) {
+      setCourseColors(colors);
+    } else {
+      changeSavedColors(savedSchedule.name, colors);
+    }
+
     toast({
       title: "Succesfully saved!",
       description: "Your course colors have been saved.",
@@ -45,8 +64,10 @@ export default function CourseColorsDialog({}: CourseColorsDialogProps) {
   };
 
   useEffect(() => {
-    setColors({ ...courseColors });
-  }, [courseColors]);
+    setColors(
+      savedSchedule ? { ...savedSchedule.colors } : { ...courseColors }
+    );
+  }, [savedSchedule, courseColors]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/SavedTab.tsx
+++ b/src/components/SavedTab.tsx
@@ -12,6 +12,7 @@ import { ChevronLeft, ChevronRight, HeartCrack } from "lucide-react";
 import { useState } from "react";
 import { FixedSizeList } from "react-window";
 import Calendar from "./Calendar";
+import CourseColorsDialog from "./CourseColorsDialog";
 import DownloadScheduleButton from "./DownloadScheduleButton";
 import SaveButton from "./SaveButton";
 import ScheduleOverview from "./ScheduleOverview";
@@ -81,6 +82,7 @@ const SavedTab = () => {
           </div>
           {schedules[active] && (
             <div className="ml-auto flex flex-row gap-2">
+              <CourseColorsDialog savedSchedule={schedules[active]} />
               <SaveButton
                 activeSched={schedules[active].classes}
                 colors={schedules[active].colors}

--- a/src/stores/useGlobalStore.ts
+++ b/src/stores/useGlobalStore.ts
@@ -67,6 +67,7 @@ interface ScheduleStates {
   savedSchedules: SavedSchedule[];
   addSavedSchedule: (schedule: SavedSchedule) => void;
   deleteSavedSchedule: (name: string) => void;
+  changeSavedColors: (name: string, colors: Record<string, ColorsEnum>) => void;
   setSavedSchedules: (schedules: SavedSchedule[]) => void;
   randomizeColors: boolean;
   setRandomizeColors: (randomizeColors: boolean) => void;
@@ -186,6 +187,18 @@ const createScheduleSlice: Slice<ScheduleStates> = (set) => ({
     set((state) => ({
       savedSchedules: state.savedSchedules.filter((s) => s.name !== name),
     })),
+  changeSavedColors: (name, colors) => {
+    set((state) => {
+      const savedSchedules = state.savedSchedules.map((s) => {
+        if (s.name === name) {
+          return { ...s, colors };
+        }
+        return s;
+      });
+
+      return { savedSchedules };
+    });
+  },
   setSavedSchedules: (schedules) => set({ savedSchedules: schedules }),
   randomizeColors: true,
   setRandomizeColors: (randomizeColors) => set({ randomizeColors }),


### PR DESCRIPTION
This pull request includes changes to the `src` directory to update the announcement details, add new features for saved schedules, and modify the global store to support these new features. The most important changes include updating the announcement content, adding the ability to change colors of saved schedules, and modifying the global store to handle these changes.

### Announcement Updates:
* [`src/components/Announcement.tsx`](diffhunk://#diff-104b29013ef22daae898159e04d6b44ed070e9c460a8fcffe6ca966090442beeL30-R44): Updated the announcement title, description, and patch date. Changed the updates to include new filters and the ability to change saved schedule colors.

### New Features for Saved Schedules:
* [`src/components/CourseColorsDialog.tsx`](diffhunk://#diff-3d16ca37c831af49a599dd255f256575c5009dfa65f1d06a1d783fb713cf15b7R1): Added support for changing colors of saved schedules by introducing a new `savedSchedule` prop and modifying the state and save logic accordingly. [[1]](diffhunk://#diff-3d16ca37c831af49a599dd255f256575c5009dfa65f1d06a1d783fb713cf15b7R1) [[2]](diffhunk://#diff-3d16ca37c831af49a599dd255f256575c5009dfa65f1d06a1d783fb713cf15b7L23-R58) [[3]](diffhunk://#diff-3d16ca37c831af49a599dd255f256575c5009dfa65f1d06a1d783fb713cf15b7L48-R70)
* [`src/components/SavedTab.tsx`](diffhunk://#diff-15469ec7938f68e18b9767e594e7ceb21d7a3728cd7788d263b3ff2197fa2223R15): Integrated the `CourseColorsDialog` component to allow users to change colors of their saved schedules directly from the saved tab. [[1]](diffhunk://#diff-15469ec7938f68e18b9767e594e7ceb21d7a3728cd7788d263b3ff2197fa2223R15) [[2]](diffhunk://#diff-15469ec7938f68e18b9767e594e7ceb21d7a3728cd7788d263b3ff2197fa2223R85)

### Global Store Modifications:
* [`src/stores/useGlobalStore.ts`](diffhunk://#diff-8724d9937ab709a45031afc35a84c2a3c019a18e4eaa1f4bbb0eb36d657b0a72R70): Added a new method `changeSavedColors` to the global store to support changing colors of saved schedules. [[1]](diffhunk://#diff-8724d9937ab709a45031afc35a84c2a3c019a18e4eaa1f4bbb0eb36d657b0a72R70) [[2]](diffhunk://#diff-8724d9937ab709a45031afc35a84c2a3c019a18e4eaa1f4bbb0eb36d657b0a72R190-R201)